### PR TITLE
Fix cookie-based user ID, people API binding, and track typings

### DIFF
--- a/.changeset/fix-cookie-people-track.md
+++ b/.changeset/fix-cookie-people-track.md
@@ -1,0 +1,11 @@
+---
+"nestjs-mixpanel": patch
+---
+
+Fix cookie-based user identification, `people` API runtime error, and `track` typings
+
+- The `cookie` strategy now uses the cookie value directly as the user ID. Previously the cookie name was also applied as an object path on the cookie value, so a plain string cookie always resolved to `undefined` and silently fell back to the request context ID.
+- `people.set` and `people.setOnce` no longer throw `TypeError: this.getIp is not a function`. The functions returned by the `people` getter are now bound to the service instance.
+- `properties` is now optional in `track`, matching the documented API (`track('event')` compiles).
+- `people.set` / `people.setOnce` are now properly typed in the published type declarations. Previously they resolved to `any` because the declaration referenced untyped private members.
+- `track` no longer passes a trailing `undefined` callback to the underlying Mixpanel SDK.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,14 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+# id-token: write is required for npm trusted publishing (OIDC).
+# contents/pull-requests: write are required by changesets/action to push the
+# release branch and open the release PR, and by the tag/release steps below.
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   release:
     name: Release
@@ -29,28 +37,53 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
+      # Trusted publishing requires npm >= 11.5.1; Node 20 bundles npm 10.
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@11
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
 
-      - name: Create Release Pull Request or Publish to npm
+      - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@v1
         with:
-          # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: pnpm changeset publish
           version: pnpm changeset version
           commit: "chore: release"
           title: "chore: release"
-          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish Success
-        if: steps.changesets.outputs.published == 'true'
+      # Publishing runs outside changesets/action so that npm authenticates via
+      # OIDC (trusted publishing) with no token and no .npmrc involved.
+      # When changesets are pending this push only updated the release PR, so
+      # publishing is skipped; when none are pending (the release PR was just
+      # merged) this publishes any version not yet on the registry.
+      - name: Publish to npm
+        id: publish
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        shell: bash
         run: |
-          echo "🎉 Successfully published to npm!"
-          echo "📦 Published packages: ${{ steps.changesets.outputs.publishedPackages }}"
+          pnpm changeset publish | tee publish-output.log
+          if grep -q "New tag:" publish-output.log; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push Git Tag and Create GitHub Release
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.publish.outputs.version }}
+        run: |
+          git push origin --tags
+          awk -v ver="$VERSION" '$0 == "## " ver {flag=1; next} /^## / {flag=0} flag' CHANGELOG.md > release-notes.md
+          if [ -s release-notes.md ]; then
+            gh release create "v${VERSION}" --title "v${VERSION}" --notes-file release-notes.md
+          else
+            gh release create "v${VERSION}" --title "v${VERSION}" --generate-notes
+          fi
+          echo "🎉 Successfully published v${VERSION} to npm"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clean": "rm -rf dist",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.ts\"",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/__tests__/mixpanel.service.test.ts
+++ b/src/__tests__/mixpanel.service.test.ts
@@ -6,10 +6,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Mock mixpanel at the module level
 const mockTrack = vi.fn();
+const mockPeopleSet = vi.fn();
+const mockPeopleSetOnce = vi.fn();
 vi.mock('mixpanel', () => ({
   default: {
     init: vi.fn(() => ({
       track: mockTrack,
+      people: {
+        set: mockPeopleSet,
+        set_once: mockPeopleSetOnce,
+      },
     })),
   },
 }));
@@ -241,6 +247,9 @@ describe('MixpanelService', () => {
       const fallbackAsyncStorageService = {
         getId: vi.fn().mockReturnValue('cls-context-456'),
         get: vi.fn(),
+        getRequest: vi.fn(),
+        getUser: vi.fn(),
+        getSession: vi.fn(),
       };
 
       const module: TestingModule = await Test.createTestingModule({
@@ -265,6 +274,98 @@ describe('MixpanelService', () => {
         action: 'click',
         distinct_id: 'cls-context-456',
       });
+    });
+  });
+
+  describe('cookie extraction', () => {
+    const createCookieService = async (cookieValue: string | undefined) => {
+      const cookieOptions: MixpanelModuleOptions = {
+        token: 'test-token',
+        cookie: 'userId',
+      };
+
+      const cookieAsyncStorageService = {
+        get: vi.fn(),
+        getId: vi.fn().mockReturnValue('default-cls-id'),
+        getRequest: vi.fn(),
+        getUser: vi.fn(),
+        getSession: vi.fn(),
+        getCookie: vi.fn().mockReturnValue(cookieValue),
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          MixpanelService,
+          {
+            provide: 'MIXPANEL_OPTIONS',
+            useValue: cookieOptions,
+          },
+          AsyncStorageService,
+        ],
+      })
+        .overrideProvider(AsyncStorageService)
+        .useValue(cookieAsyncStorageService)
+        .compile();
+
+      return {
+        cookieService: module.get<MixpanelService>(MixpanelService),
+        cookieAsyncStorageService,
+      };
+    };
+
+    it('should use the cookie value as the user ID', async () => {
+      const { cookieService, cookieAsyncStorageService } = await createCookieService('abc123');
+
+      expect(cookieService.extractUserId()).toBe('abc123');
+      expect(cookieAsyncStorageService.getCookie).toHaveBeenCalledWith('userId');
+    });
+
+    it('should fallback to AsyncStorage context ID when the cookie is missing', async () => {
+      const { cookieService } = await createCookieService(undefined);
+
+      expect(cookieService.extractUserId()).toBe('default-cls-id');
+    });
+  });
+
+  describe('people', () => {
+    beforeEach(() => {
+      asyncStorageService.getRequest.mockReturnValue({
+        headers: { 'x-user-id': 'user-123' },
+      });
+    });
+
+    it('should set profile properties with an explicit distinct ID', () => {
+      service.people.set('explicit-id', { name: 'John' });
+
+      expect(mockPeopleSet).toHaveBeenCalledWith('explicit-id', { name: 'John' }, {}, undefined);
+    });
+
+    it('should set profile properties using the extracted user ID', () => {
+      service.people.set({ name: 'John' });
+
+      expect(mockPeopleSet).toHaveBeenCalledWith('user-123', { name: 'John' }, {}, undefined);
+    });
+
+    it('should set profile properties once with an explicit distinct ID', () => {
+      service.people.setOnce('explicit-id', { created_at: '2025-01-01' });
+
+      expect(mockPeopleSetOnce).toHaveBeenCalledWith(
+        'explicit-id',
+        { created_at: '2025-01-01' },
+        {},
+        undefined,
+      );
+    });
+
+    it('should set profile properties once using the extracted user ID', () => {
+      service.people.setOnce({ created_at: '2025-01-01' });
+
+      expect(mockPeopleSetOnce).toHaveBeenCalledWith(
+        'user-123',
+        { created_at: '2025-01-01' },
+        {},
+        undefined,
+      );
     });
   });
 });

--- a/src/mixpanel.service.ts
+++ b/src/mixpanel.service.ts
@@ -6,9 +6,25 @@ import { MIXPANEL_OPTIONS } from './constant.js';
 
 type TrackFunction = (
   event: string,
-  properties: Mixpanel.PropertyDict,
+  properties?: Mixpanel.PropertyDict,
   callback?: Mixpanel.Callback,
 ) => void;
+
+type PeopleFunction = {
+  (
+    distinctId: string,
+    properties: Mixpanel.PropertyDict,
+    modifiers?: Mixpanel.Modifiers,
+    callback?: Mixpanel.Callback,
+  ): void;
+  (distinctId: string, properties: Mixpanel.PropertyDict, callback: Mixpanel.Callback): void;
+  (
+    properties: Mixpanel.PropertyDict,
+    modifiers?: Mixpanel.Modifiers,
+    callback?: Mixpanel.Callback,
+  ): void;
+  (properties: Mixpanel.PropertyDict, callback: Mixpanel.Callback): void;
+};
 
 @Injectable()
 export class MixpanelService {
@@ -30,7 +46,11 @@ export class MixpanelService {
       ...properties,
     };
 
-    this.mixpanel.track(event, finalProperties, callback);
+    if (callback) {
+      this.mixpanel.track(event, finalProperties, callback);
+    } else {
+      this.mixpanel.track(event, finalProperties);
+    }
   };
 
   private peopleSet(
@@ -149,10 +169,10 @@ export class MixpanelService {
     }
   }
 
-  get people() {
+  get people(): { set: PeopleFunction; setOnce: PeopleFunction } {
     return {
-      set: this.peopleSet,
-      setOnce: this.peopleSetOnce,
+      set: this.peopleSet.bind(this) as PeopleFunction,
+      setOnce: this.peopleSetOnce.bind(this) as PeopleFunction,
     };
   }
 
@@ -199,8 +219,7 @@ export class MixpanelService {
         const user = this.asyncStorage.getUser();
         userId = this.extractValue(this.options.user, user);
       } else if ('cookie' in this.options) {
-        const cookie = this.asyncStorage.getCookie(this.options.cookie);
-        userId = this.extractValue(this.options.cookie, cookie);
+        userId = this.asyncStorage.getCookie(this.options.cookie);
       }
 
       // Fallback to AsyncStorage context ID if no specific field is configured or extraction failed


### PR DESCRIPTION
## Summary
This PR fixes several issues in the MixpanelService related to user identification, the people API, and type safety.

## Key Changes

- **Cookie-based user identification**: Fixed the cookie strategy to use the cookie value directly as the user ID. Previously, the cookie name was incorrectly applied as an object path on the cookie value, causing plain string cookies to always resolve to `undefined` and silently fall back to the request context ID.

- **People API runtime error**: Fixed `people.set` and `people.setOnce` throwing `TypeError: this.getIp is not a function` by properly binding these methods to the service instance in the `people` getter.

- **Track method typings**: Made the `properties` parameter optional in the `track` method signature to match the documented API and allow calls like `track('event')` to compile.

- **People API type declarations**: Added proper TypeScript overload signatures for `people.set` and `people.setOnce` to support both explicit distinct ID and auto-extracted user ID variants. Previously these resolved to `any` in published type declarations.

- **Track callback handling**: Removed passing a trailing `undefined` callback to the underlying Mixpanel SDK when no callback is provided.

- **Test coverage**: Added comprehensive test cases for cookie extraction and people API functionality, including mocking of `people.set` and `people.setOnce` methods.

- **CI/CD improvements**: Updated the release workflow to use npm trusted publishing (OIDC) instead of token-based authentication, and separated the release PR creation from the npm publishing step.

- **Developer tooling**: Added a `typecheck` script to the package.json for type checking without emitting files.

## Implementation Details

The `PeopleFunction` type uses function overloads to properly type the dual-signature nature of the people API methods, allowing them to be called with either an explicit distinct ID or relying on automatic user ID extraction from the request context.

https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS