### PR TITLE
Add repository field required by provenance validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
   ],
   "author": "ESnark<settimeout1000@gmail.com>",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ESnark/nestjs-mixpanel.git"
+  },
   "packageManager": "pnpm@10.8.0",
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary

The first trusted-publishing run ([run #9](https://github.com/ESnark/nestjs-mixpanel/actions/runs/33038707981)) failed with:

```
E422 Unprocessable Entity - PUT https://registry.npmjs.org/nestjs-mixpanel
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/ESnark/nestjs-mixpanel" from provenance
```

OIDC authentication and provenance signing succeeded — the registry rejected the publish because provenance validation requires `package.json`'s `repository` field to match the repository the package was built from, and the field was missing entirely.

## Changes

- Add the `repository` field to `package.json` pointing at this repository.

## Release Note

This PR intentionally has **no changeset**: version 1.5.1 is already bumped on `main` but not yet published. Merging this triggers the Release workflow's publish step directly (no pending changesets), which publishes 1.5.1 including this fix. Adding a changeset instead would open a 1.5.2 release PR and 1.5.1 would never be published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS)_