### PR TITLE
v2.0.0: Safe anonymous identity default, peer dependencies, mixpanel ^0.23

### DIFF
--- a/.changeset/major-safe-identity-default.md
+++ b/.changeset/major-safe-identity-default.md
@@ -1,0 +1,16 @@
+---
+"nestjs-mixpanel": major
+---
+
+Replace the per-request UUID identity fallback with a safe anonymous default, move NestJS packages to peerDependencies, and upgrade the Mixpanel SDK to ^0.23
+
+**Breaking changes**
+
+- **Anonymous identity by default.** When no identification strategy is configured, or the configured strategy fails to extract an ID, events are now sent with an empty `distinct_id` (Mixpanel's documented "not associated with any user" value) instead of a random UUID generated per request. The old behavior made every request look like a different user, corrupting unique-user counts, funnels, and retention. Opt back into it with `fallback: 'request-context'`, or provide a custom resolver: `fallback: (request) => request?.sessionID`. A warning is logged once when a configured strategy fails to extract an ID.
+- **`people.set()` / `people.setOnce()` without an explicit distinct ID are skipped** (with a warning) when no user identity can be resolved, instead of writing a profile to a throwaway identity.
+- **`@nestjs/common`, `@nestjs/core`, `reflect-metadata`, and `rxjs` are now peerDependencies** provided by your application, so the module always shares your app's Nest instance.
+- **`mixpanel` upgraded from `^0.18.1` to `^0.23.0`.** Known upstream issue: mixpanel 0.23.0 crashes on `init` when `HTTPS_PROXY`/`HTTP_PROXY` is set in the environment (it constructs the `https-proxy-agent` v7 module namespace instead of its named export).
+
+**Added**
+
+- `fallback` module option (`'anonymous' | 'request-context' | (request) => string | undefined`) and the exported `FallbackIdStrategy` type.

--- a/README.md
+++ b/README.md
@@ -59,16 +59,33 @@ export class AnalyticsService {
 The module provides multiple strategies to automatically identify users:
 
 
-#### 1. AsyncStorage Context ID (Default)
+#### 1. Anonymous (Default)
 
-If no identification strategy is specified, the module will use a unique ID from the AsyncLocalStorage context:
+If no identification strategy is specified — or the configured strategy fails to extract an ID for a request — events are sent with an empty `distinct_id`. This is Mixpanel's documented way to send events that are not associated with any user, so unresolved identities never pollute unique-user counts, funnels, or retention reports:
 
 ```typescript
 MixpanelModule.forRoot({
   token: 'YOUR_MIXPANEL_TOKEN',
-  // Will use AsyncLocalStorage context ID as distinct_id
+  // Events without a resolved user ID are sent anonymously (distinct_id: '')
 })
 ```
+
+When a strategy is configured but extraction fails, a warning is logged once so silent misconfigurations are visible.
+
+You can change what happens when no user ID is resolved with the `fallback` option:
+
+```typescript
+MixpanelModule.forRoot({
+  token: 'YOUR_MIXPANEL_TOKEN',
+  user: 'id',
+  // 'anonymous' (default): distinct_id is '' when extraction fails
+  // 'request-context':     use a random UUID generated per request (v1 behavior)
+  // custom resolver:       derive an ID from the request yourself
+  fallback: (request: any) => request?.sessionID,
+})
+```
+
+> **Warning**: `fallback: 'request-context'` restores the pre-2.0 behavior. Because the ID is regenerated on every request, the same user appears as a different user on each request — unique-user counts, funnels, and retention will be distorted. Prefer the default or a resolver backed by something request-independent (e.g. a session ID).
 
 #### 2. Header-based Identification
 
@@ -243,7 +260,9 @@ this.mixpanel.people.setOnce({
 
 #### `extractUserId(): string | undefined`
 
-Internal method that extracts the user ID based on the configured identification strategy. Returns the extracted user ID or falls back to the AsyncLocalStorage context ID.
+Internal method that extracts the user ID based on the configured identification strategy. Returns the extracted user ID, the result of the configured `fallback` strategy, or `undefined` when the identity stays anonymous.
+
+Note: `people.set()` / `people.setOnce()` calls without an explicit distinct ID are skipped (with a warning) when no user identity can be resolved — profile updates are never written to an anonymous or per-request identity.
 
 ## Advanced Usage
 
@@ -289,4 +308,13 @@ pnpm test:ui      # Open test UI
 ### Requirements
 
 - Node.js >= 20.0.0
-- NestJS >= 11.0.0
+- NestJS >= 11.0.0 (peer dependency — provided by your application)
+
+## Migrating from 1.x
+
+Version 2.0.0 contains the following breaking changes:
+
+1. **The per-request UUID fallback is no longer the default.** In 1.x, when no identification strategy was configured or extraction failed, `distinct_id` was set to a random UUID generated per request — which made every request look like a different user and corrupted unique-user counts, funnels, and retention. In 2.x the default is anonymous (`distinct_id: ''`). If you depended on the old behavior, opt back in with `fallback: 'request-context'`.
+2. **`people.set()` / `people.setOnce()` without an explicit distinct ID are skipped** (with a warning) when no user identity can be resolved, instead of creating a throwaway profile.
+3. **`@nestjs/common`, `@nestjs/core`, `reflect-metadata`, and `rxjs` are now peer dependencies.** Your application provides them (it already does in any NestJS project), so the module always uses your app's Nest instance.
+4. **The bundled Mixpanel SDK is upgraded from `mixpanel@^0.18` to `mixpanel@^0.23`.** Note: mixpanel 0.23.0 has an upstream bug that crashes `init` when an `HTTPS_PROXY`/`HTTP_PROXY` environment variable is set (it constructs the `https-proxy-agent` v7 module namespace instead of its named export). If your servers sit behind an HTTP proxy, unset those variables for the process or wait for an upstream fix.

--- a/package.json
+++ b/package.json
@@ -51,20 +51,23 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@nestjs/common": "^11.1.3",
-    "@nestjs/core": "^11.1.3",
-    "mixpanel": "^0.18.1",
-    "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.2"
+    "mixpanel": "^0.23.0"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "reflect-metadata": "^0.2.0",
+    "rxjs": "^7.8.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.5",
     "@eslint/js": "^9.30.1",
+    "@nestjs/common": "^11.1.3",
+    "@nestjs/core": "^11.1.3",
     "@nestjs/platform-express": "^11.1.3",
     "@nestjs/testing": "^11.1.3",
     "@swc/core": "^1.12.11",
     "@types/express": "^5.0.3",
-    "@types/mixpanel": "^2.14.9",
     "@types/node": "^24.0.12",
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.36.0",
@@ -75,6 +78,8 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.5.1",
     "prettier": "^3.6.2",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.2",
     "supertest": "^7.1.3",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,21 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@nestjs/common':
-        specifier: ^11.1.3
-        version: 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core':
-        specifier: ^11.1.3
-        version: 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       mixpanel:
-        specifier: ^0.18.1
-        version: 0.18.1
-      reflect-metadata:
-        specifier: ^0.2.2
-        version: 0.2.2
-      rxjs:
-        specifier: ^7.8.2
-        version: 7.8.2
+        specifier: ^0.23.0
+        version: 0.23.0
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.5
@@ -30,6 +18,12 @@ importers:
       '@eslint/js':
         specifier: ^9.30.1
         version: 9.30.1
+      '@nestjs/common':
+        specifier: ^11.1.3
+        version: 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.1.3
+        version: 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^11.1.3
         version: 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)
@@ -42,9 +36,6 @@ importers:
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.3
-      '@types/mixpanel':
-        specifier: ^2.14.9
-        version: 2.14.9
       '@types/node':
         specifier: ^24.0.12
         version: 24.0.12
@@ -75,6 +66,12 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
       supertest:
         specifier: ^7.1.3
         version: 7.1.3
@@ -726,9 +723,6 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
-  '@types/mixpanel@2.14.9':
-    resolution: {integrity: sha512-/0xAtxlluEBz3f/cmM04tVTmP94mPEME6TBl+kKA7HtPWlvxH/fMSmp4ZdV2b/SN+7FLHm/aR6Fau8wZrjvoZQ==}
-
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -869,9 +863,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -1404,9 +1398,9 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
-  https-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==}
-    engines: {node: '>= 6'}
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-id@4.1.1:
     resolution: {integrity: sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg==}
@@ -1516,6 +1510,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-logic-js@2.0.5:
+    resolution: {integrity: sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -1644,8 +1641,8 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mixpanel@0.18.1:
-    resolution: {integrity: sha512-YD1xfn6WP6ZLQ6Pmgh0KgdXhueJEsrodThMTsHzHMH0VbWa9ck8s+ynDtM83OSgt+yQ61W/SQNrH8Y4wIwocGg==}
+  mixpanel@0.23.0:
+    resolution: {integrity: sha512-2kaFTdeFgfOsG0l0dW40fBFgCUeVY/LtgxOZgaRvXQd9sNrtZe7Xq2aoc0hkaOC7pZTrH8UVFnliFDlGQtUz/w==}
     engines: {node: '>=10.0'}
 
   mkdirp@0.5.6:
@@ -2902,8 +2899,6 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
-  '@types/mixpanel@2.14.9': {}
-
   '@types/node@12.20.55': {}
 
   '@types/node@24.0.12':
@@ -3112,11 +3107,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
+  agent-base@7.1.4: {}
 
   ajv@6.12.6:
     dependencies:
@@ -3711,9 +3702,9 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
-  https-proxy-agent@5.0.0:
+  https-proxy-agent@7.0.6:
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 7.1.4
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
@@ -3808,6 +3799,8 @@ snapshots:
       argparse: 2.0.1
 
   json-buffer@3.0.1: {}
+
+  json-logic-js@2.0.5: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -3909,9 +3902,10 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mixpanel@0.18.1:
+  mixpanel@0.23.0:
     dependencies:
-      https-proxy-agent: 5.0.0
+      https-proxy-agent: 7.0.6
+      json-logic-js: 2.0.5
     transitivePeerDependencies:
       - supports-color
 

--- a/src/__tests__/e2e/mixpanel-simple.e2e.test.ts
+++ b/src/__tests__/e2e/mixpanel-simple.e2e.test.ts
@@ -231,7 +231,7 @@ describe('MixpanelModule Simple E2E Tests', () => {
     expect(response.body.userId).toBe('user-object-111');
   });
 
-  it('should fallback to AsyncStorage context ID when no option is configured', async () => {
+  it('should use the request context ID when fallback is request-context', async () => {
     @Controller('test')
     class TestController {
       constructor(@Inject(MixpanelService) private readonly mixpanelService: MixpanelService) {}
@@ -246,6 +246,7 @@ describe('MixpanelModule Simple E2E Tests', () => {
       imports: [
         MixpanelModule.forRoot({
           token: 'test-token',
+          fallback: 'request-context',
         }),
       ],
       controllers: [TestController],

--- a/src/__tests__/e2e/mixpanel-stress.e2e.test.ts
+++ b/src/__tests__/e2e/mixpanel-stress.e2e.test.ts
@@ -42,6 +42,7 @@ class TestController {
     MixpanelModule.forRoot({
       token: 'test-token',
       header: 'x-user-id',
+      fallback: 'request-context',
     }),
   ],
   controllers: [TestController],

--- a/src/__tests__/e2e/mixpanel.e2e.test.ts
+++ b/src/__tests__/e2e/mixpanel.e2e.test.ts
@@ -104,11 +104,10 @@ describe('MixpanelModule E2E Tests', () => {
       });
     });
 
-    it('should fallback to AsyncStorage context ID when header is missing', async () => {
+    it('should return no user ID when header is missing (anonymous default)', async () => {
       const response = await request(app.getHttpServer()).post('/extract-user-id').expect(201);
 
-      expect(response.body.userId).toBeDefined();
-      expect(response.body.userId).toMatch(/^[a-zA-Z0-9-]+$/); // AsyncStorage generates UUID-like IDs
+      expect(response.body.userId).toBeUndefined();
     });
   });
 
@@ -283,7 +282,7 @@ describe('MixpanelModule E2E Tests', () => {
 
   describe('AsyncStorage Context', () => {
     it('should properly clean up AsyncStorage context', async () => {
-      const TestModule = createTestModule({});
+      const TestModule = createTestModule({ fallback: 'request-context' });
 
       const moduleFixture: TestingModule = await Test.createTestingModule({
         imports: [TestModule],

--- a/src/__tests__/integration/mixpanel.integration.test.ts
+++ b/src/__tests__/integration/mixpanel.integration.test.ts
@@ -74,7 +74,7 @@ describe('MixpanelModule Integration Tests', () => {
       });
     });
 
-    it('should fallback to AsyncStorage ID when header is missing', () => {
+    it('should return undefined when header is missing (anonymous default)', () => {
       const testContext = {
         id: 'cls-fallback-id',
         [REQUEST_CTX_KEY]: {
@@ -84,7 +84,7 @@ describe('MixpanelModule Integration Tests', () => {
 
       asyncStorageService.enterWith(testContext);
       const userId = mixpanelService.extractUserId();
-      expect(userId).toBe('cls-fallback-id');
+      expect(userId).toBeUndefined();
     });
   });
 
@@ -143,7 +143,7 @@ describe('MixpanelModule Integration Tests', () => {
       });
     });
 
-    it('should fallback to AsyncStorage ID when session path is invalid', () => {
+    it('should return undefined when session path is invalid (anonymous default)', () => {
       // Use enterWith to set context
       const testContext = {
         id: 'cls-session-fallback',
@@ -154,7 +154,7 @@ describe('MixpanelModule Integration Tests', () => {
 
       asyncStorageService.enterWith(testContext);
       const userId = mixpanelService.extractUserId();
-      expect(userId).toBe('cls-session-fallback');
+      expect(userId).toBeUndefined();
     });
   });
 
@@ -214,7 +214,7 @@ describe('MixpanelModule Integration Tests', () => {
     });
   });
 
-  describe('Fallback to AsyncStorage context ID', () => {
+  describe('Anonymous default', () => {
     beforeEach(async () => {
       module = await Test.createTestingModule({
         imports: [
@@ -228,7 +228,49 @@ describe('MixpanelModule Integration Tests', () => {
       asyncStorageService = module.get<AsyncStorageService>(AsyncStorageService);
     });
 
-    it('should use AsyncStorage context ID when no extraction option is configured', () => {
+    it('should return undefined when no extraction option is configured', () => {
+      const testContext = {
+        id: 'default-context-id',
+        [REQUEST_CTX_KEY]: {},
+      };
+
+      asyncStorageService.enterWith(testContext);
+      const userId = mixpanelService.extractUserId();
+      expect(userId).toBeUndefined();
+    });
+
+    it('should track events with an empty distinct_id', () => {
+      const testContext = {
+        id: 'context-track-id',
+        [REQUEST_CTX_KEY]: {},
+      };
+
+      asyncStorageService.enterWith(testContext);
+      mixpanelService.track('default-event', { type: 'test' });
+
+      expect(mockTrack).toHaveBeenCalledWith('default-event', {
+        type: 'test',
+        distinct_id: '',
+      });
+    });
+  });
+
+  describe('Fallback: request-context', () => {
+    beforeEach(async () => {
+      module = await Test.createTestingModule({
+        imports: [
+          MixpanelModule.forRoot({
+            token: 'test-token',
+            fallback: 'request-context',
+          }),
+        ],
+      }).compile();
+
+      mixpanelService = module.get<MixpanelService>(MixpanelService);
+      asyncStorageService = module.get<AsyncStorageService>(AsyncStorageService);
+    });
+
+    it('should use the AsyncStorage context ID', () => {
       const testContext = {
         id: 'default-context-id',
         [REQUEST_CTX_KEY]: {},
@@ -239,7 +281,7 @@ describe('MixpanelModule Integration Tests', () => {
       expect(userId).toBe('default-context-id');
     });
 
-    it('should track events with AsyncStorage context ID', () => {
+    it('should track events with the AsyncStorage context ID', () => {
       const testContext = {
         id: 'context-track-id',
         [REQUEST_CTX_KEY]: {},

--- a/src/__tests__/mixpanel.module.test.ts
+++ b/src/__tests__/mixpanel.module.test.ts
@@ -3,7 +3,15 @@ import { MixpanelModule } from '../mixpanel.module.js';
 import { MixpanelService } from '../mixpanel.service.js';
 import { AsyncStorageService } from '../async-storage.service.js';
 import { MixpanelModuleOptions, MixpanelModuleAsyncOptions } from '../interface.js';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
+
+// mixpanel@0.23.0 crashes on init when HTTP(S)_PROXY is set (it news the
+// https-proxy-agent v7 module namespace instead of its named export), so
+// clear proxy variables for the un-mocked init calls in this file.
+beforeAll(() => {
+  delete process.env.HTTPS_PROXY;
+  delete process.env.HTTP_PROXY;
+});
 
 describe('MixpanelModule', () => {
   describe('forRoot', () => {

--- a/src/__tests__/mixpanel.service.test.ts
+++ b/src/__tests__/mixpanel.service.test.ts
@@ -59,6 +59,33 @@ describe('MixpanelService', () => {
     vi.clearAllMocks();
   });
 
+  const createServiceWithOptions = async (options: MixpanelModuleOptions) => {
+    const asyncStorage = {
+      get: vi.fn(),
+      getId: vi.fn().mockReturnValue('cls-context-123'),
+      getRequest: vi.fn(),
+      getUser: vi.fn(),
+      getSession: vi.fn(),
+      getCookie: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MixpanelService,
+        {
+          provide: 'MIXPANEL_OPTIONS',
+          useValue: options,
+        },
+        AsyncStorageService,
+      ],
+    })
+      .overrideProvider(AsyncStorageService)
+      .useValue(asyncStorage)
+      .compile();
+
+    return { service: module.get<MixpanelService>(MixpanelService), asyncStorage };
+  };
+
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
@@ -73,7 +100,7 @@ describe('MixpanelService', () => {
       service.track(event);
 
       expect(mockTrack).toHaveBeenCalledWith(event, {
-        distinct_id: 'default-cls-id', // Fallback to AsyncStorage ID when header is missing
+        distinct_id: '', // Anonymous when header is missing
       });
     });
 
@@ -88,7 +115,7 @@ describe('MixpanelService', () => {
 
       expect(mockTrack).toHaveBeenCalledWith(event, {
         action: 'click',
-        distinct_id: 'default-cls-id', // Fallback to AsyncStorage ID when header is missing
+        distinct_id: '', // Anonymous when header is missing
       });
     });
 
@@ -117,7 +144,7 @@ describe('MixpanelService', () => {
       service.track(event);
 
       expect(mockTrack).toHaveBeenCalledWith(event, {
-        distinct_id: 'default-cls-id', // Should fallback to AsyncStorage ID
+        distinct_id: '', // Anonymous when there is no request context
       });
     });
   });
@@ -205,75 +232,66 @@ describe('MixpanelService', () => {
       expect(userId).toBe('user-456');
     });
 
-    it('should fallback to AsyncStorage context ID when no specific field is configured', async () => {
-      const fallbackOptions: MixpanelModuleOptions = {
+    it('should return undefined when no strategy is configured (anonymous default)', async () => {
+      const { service: fallbackService, asyncStorage } = await createServiceWithOptions({
         token: 'test-token',
-      };
-
-      const fallbackAsyncStorageService = {
-        getId: vi.fn().mockReturnValue('cls-context-123'),
-        get: vi.fn(),
-        getRequest: vi.fn(),
-        getUser: vi.fn(),
-        getSession: vi.fn(),
-      };
-
-      const module: TestingModule = await Test.createTestingModule({
-        providers: [
-          MixpanelService,
-          {
-            provide: 'MIXPANEL_OPTIONS',
-            useValue: fallbackOptions,
-          },
-          AsyncStorageService,
-        ],
-      })
-        .overrideProvider(AsyncStorageService)
-        .useValue(fallbackAsyncStorageService)
-        .compile();
-
-      const fallbackService = module.get<MixpanelService>(MixpanelService);
+      });
 
       const userId = fallbackService.extractUserId();
-      expect(userId).toBe('cls-context-123');
-      expect(fallbackAsyncStorageService.getId).toHaveBeenCalled();
+      expect(userId).toBeUndefined();
+      expect(asyncStorage.getId).not.toHaveBeenCalled();
     });
 
-    it('should use AsyncStorage context ID in tracking when no specific field is configured', async () => {
-      const fallbackOptions: MixpanelModuleOptions = {
+    it('should track anonymously when no strategy is configured (anonymous default)', async () => {
+      const { service: fallbackService } = await createServiceWithOptions({
         token: 'test-token',
-      };
-
-      const fallbackAsyncStorageService = {
-        getId: vi.fn().mockReturnValue('cls-context-456'),
-        get: vi.fn(),
-        getRequest: vi.fn(),
-        getUser: vi.fn(),
-        getSession: vi.fn(),
-      };
-
-      const module: TestingModule = await Test.createTestingModule({
-        providers: [
-          MixpanelService,
-          {
-            provide: 'MIXPANEL_OPTIONS',
-            useValue: fallbackOptions,
-          },
-          AsyncStorageService,
-        ],
-      })
-        .overrideProvider(AsyncStorageService)
-        .useValue(fallbackAsyncStorageService)
-        .compile();
-
-      const fallbackService = module.get<MixpanelService>(MixpanelService);
+      });
 
       fallbackService.track('test-event', { action: 'click' });
 
       expect(mockTrack).toHaveBeenCalledWith('test-event', {
         action: 'click',
-        distinct_id: 'cls-context-456',
+        distinct_id: '',
       });
+    });
+
+    it('should use the request context ID when fallback is request-context', async () => {
+      const { service: fallbackService, asyncStorage } = await createServiceWithOptions({
+        token: 'test-token',
+        fallback: 'request-context',
+      });
+
+      const userId = fallbackService.extractUserId();
+      expect(userId).toBe('cls-context-123');
+      expect(asyncStorage.getId).toHaveBeenCalled();
+
+      fallbackService.track('test-event', { action: 'click' });
+      expect(mockTrack).toHaveBeenCalledWith('test-event', {
+        action: 'click',
+        distinct_id: 'cls-context-123',
+      });
+    });
+
+    it('should use a custom fallback resolver when provided', async () => {
+      const fallbackFn = vi.fn().mockReturnValue('session-abc');
+      const { service: fallbackService, asyncStorage } = await createServiceWithOptions({
+        token: 'test-token',
+        fallback: fallbackFn,
+      });
+      asyncStorage.getRequest.mockReturnValue({ sessionID: 'session-abc' });
+
+      const userId = fallbackService.extractUserId();
+      expect(userId).toBe('session-abc');
+      expect(fallbackFn).toHaveBeenCalledWith({ sessionID: 'session-abc' });
+    });
+
+    it('should stay anonymous when the custom fallback resolver returns undefined', async () => {
+      const { service: fallbackService } = await createServiceWithOptions({
+        token: 'test-token',
+        fallback: () => undefined,
+      });
+
+      expect(fallbackService.extractUserId()).toBeUndefined();
     });
   });
 
@@ -320,10 +338,10 @@ describe('MixpanelService', () => {
       expect(cookieAsyncStorageService.getCookie).toHaveBeenCalledWith('userId');
     });
 
-    it('should fallback to AsyncStorage context ID when the cookie is missing', async () => {
+    it('should return undefined when the cookie is missing (anonymous default)', async () => {
       const { cookieService } = await createCookieService(undefined);
 
-      expect(cookieService.extractUserId()).toBe('default-cls-id');
+      expect(cookieService.extractUserId()).toBeUndefined();
     });
   });
 
@@ -366,6 +384,22 @@ describe('MixpanelService', () => {
         {},
         undefined,
       );
+    });
+
+    it('should skip people.set when no user identity is resolved', () => {
+      asyncStorageService.getRequest.mockReturnValue({ headers: {} });
+
+      service.people.set({ name: 'John' });
+
+      expect(mockPeopleSet).not.toHaveBeenCalled();
+    });
+
+    it('should skip people.setOnce when no user identity is resolved', () => {
+      asyncStorageService.getRequest.mockReturnValue({ headers: {} });
+
+      service.people.setOnce({ created_at: '2025-01-01' });
+
+      expect(mockPeopleSetOnce).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
 export { MixpanelModule } from './mixpanel.module.js';
 export * from './mixpanel.service.js';
-export type { MixpanelModuleOptions, MixpanelModuleAsyncOptions } from './interface.js';
+export type {
+  MixpanelModuleOptions,
+  MixpanelModuleAsyncOptions,
+  FallbackIdStrategy,
+} from './interface.js';

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -7,10 +7,26 @@ type MixpanelProjectToken = string;
 
 type IpHeaderOption = 'X-Forwarded-For' | 'X-Real-IP' | 'Forwarded';
 
+/**
+ * Determines the identity used when no user ID could be extracted:
+ * - `'anonymous'` (default): events are sent with an empty `distinct_id`,
+ *   so they are not associated with any user in Mixpanel
+ * - `'request-context'`: events use a random UUID generated per request
+ *   (the pre-2.0 behavior; every request looks like a different user)
+ * - custom resolver: receives the current request object (`undefined`
+ *   outside of a request context) and returns a `distinct_id`, or
+ *   `undefined` to fall back to anonymous
+ */
+export type FallbackIdStrategy =
+  | 'anonymous'
+  | 'request-context'
+  | ((request: unknown) => string | undefined);
+
 type CommonModuleOptions = {
   token: MixpanelProjectToken;
   initConfig?: InitConfig;
   ipHeader?: IpHeaderOption;
+  fallback?: FallbackIdStrategy;
 };
 
 export type MixpanelModuleOptions =

--- a/src/mixpanel.service.ts
+++ b/src/mixpanel.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
 import { AsyncStorageService } from './async-storage.service.js';
 import Mixpanel from 'mixpanel';
 import type { MixpanelModuleOptions } from './interface.js';
@@ -28,7 +28,9 @@ type PeopleFunction = {
 
 @Injectable()
 export class MixpanelService {
+  private readonly logger = new Logger(MixpanelService.name);
   private readonly mixpanel: Mixpanel.Mixpanel;
+  private warnedExtractionFailure = false;
 
   constructor(
     @Inject(MIXPANEL_OPTIONS) private readonly options: MixpanelModuleOptions,
@@ -41,7 +43,10 @@ export class MixpanelService {
     const userId = this.extractUserId();
     const ip = this.getIp();
     const finalProperties = {
-      ...(userId && { distinct_id: userId }),
+      // An empty distinct_id is Mixpanel's documented way to send an event
+      // that is not associated with any user, so unresolved identities do
+      // not pollute unique-user counts.
+      distinct_id: userId ?? '',
       ...(ip && { ip }),
       ...properties,
     };
@@ -93,6 +98,12 @@ export class MixpanelService {
     } else {
       // properties, modifiers?, callback?
       const userId = this.extractUserId();
+      if (!userId) {
+        this.logger.warn(
+          'Skipping people.set: no user identity could be resolved for the current context. Pass an explicit distinct ID or configure an identification strategy.',
+        );
+        return;
+      }
       const properties = arg1;
       let modifiers: Mixpanel.Modifiers;
       let callback: Mixpanel.Callback | undefined;
@@ -151,6 +162,12 @@ export class MixpanelService {
     } else {
       // properties, modifiers?, callback?
       const userId = this.extractUserId();
+      if (!userId) {
+        this.logger.warn(
+          'Skipping people.setOnce: no user identity could be resolved for the current context. Pass an explicit distinct ID or configure an identification strategy.',
+        );
+        return;
+      }
       const properties = arg1;
       let modifiers: Mixpanel.Modifiers;
       let callback: Mixpanel.Callback | undefined;
@@ -208,6 +225,7 @@ export class MixpanelService {
   extractUserId(): string | undefined {
     try {
       let userId: string | undefined;
+      let strategyConfigured = true;
 
       if ('header' in this.options) {
         const request = this.asyncStorage.getRequest();
@@ -220,14 +238,38 @@ export class MixpanelService {
         userId = this.extractValue(this.options.user, user);
       } else if ('cookie' in this.options) {
         userId = this.asyncStorage.getCookie(this.options.cookie);
+      } else {
+        strategyConfigured = false;
       }
 
-      // Fallback to AsyncStorage context ID if no specific field is configured or extraction failed
-      return userId || this.asyncStorage.getId();
+      if (userId) {
+        return userId;
+      }
+
+      if (strategyConfigured && !this.warnedExtractionFailure) {
+        this.warnedExtractionFailure = true;
+        this.logger.warn(
+          'Could not extract a user ID with the configured identification strategy; the fallback identity will be used. This is logged only once.',
+        );
+      }
+
+      return this.resolveFallbackId();
     } catch (error) {
-      console.warn('Failed to extract user ID from request:', error);
+      this.logger.warn(`Failed to extract user ID from request: ${error}`);
     }
 
+    return undefined;
+  }
+
+  private resolveFallbackId(): string | undefined {
+    const fallback = this.options.fallback ?? 'anonymous';
+
+    if (fallback === 'request-context') {
+      return this.asyncStorage.getId();
+    }
+    if (typeof fallback === 'function') {
+      return fallback(this.asyncStorage.getRequest()) || undefined;
+    }
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

Major release removing the analytics-corrupting per-request UUID identity fallback and modernizing the package's dependency structure. Contains a major changeset — merging this opens the 2.0.0 release PR.

## Breaking Changes

### Anonymous identity by default

When no identification strategy is configured, or the configured strategy fails to extract a user ID, events are now sent with an empty `distinct_id` — Mixpanel's documented value for events not associated with any user. Previously a random UUID was generated **per request**, which made every request look like a different user and corrupted unique-user counts, funnels, and retention.

A new `fallback` option controls this behavior:

```typescript
MixpanelModule.forRoot({
  token: '...',
  user: 'id',
  fallback: 'anonymous',        // default: distinct_id '' when no ID resolves
  // fallback: 'request-context', // opt back into the v1 per-request UUID
  // fallback: (request) => request?.sessionID, // custom resolver
})
```

A warning is logged once when a configured strategy fails to extract an ID, so silent misconfigurations (like the v1.5.0 cookie bug) become visible.

### `people.set` / `people.setOnce` skip unresolved identities

Calls without an explicit distinct ID are skipped with a warning when no user identity can be resolved, instead of writing a profile to a throwaway identity.

### Peer dependencies

`@nestjs/common`, `@nestjs/core`, `reflect-metadata`, and `rxjs` moved from `dependencies` to `peerDependencies`, so the module always shares the application's Nest instance instead of potentially resolving its own copy.

### Mixpanel SDK `^0.18.1` → `^0.23.0`

Catches up with ~18 months of upstream releases (service account auth, feature flags infrastructure, OpenFeature provider packages). `@types/mixpanel` is dropped in favor of the SDK's bundled types.

> **Known upstream issue**: mixpanel 0.23.0 crashes on `init` when `HTTPS_PROXY`/`HTTP_PROXY` is set in the environment — it constructs the `https-proxy-agent` v7 module namespace instead of its named export. Documented in the README migration guide; the module unit tests clear those variables since they exercise the real `init`.

## Other Changes

- New exported `FallbackIdStrategy` type.
- README: rewritten default-identity section, `fallback` documentation, and a "Migrating from 1.x" guide.
- Tests extended to 69 (anonymous default, `request-context` opt-in, custom resolvers, people skip behavior); all pass alongside `tsc`, lint, build, and a consumer-side typecheck of the published declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS)_