### PR TITLE
Add CI workflow, Dependabot, and underlying client escape hatch

### DIFF
--- a/.changeset/expose-underlying-client.md
+++ b/.changeset/expose-underlying-client.md
@@ -1,0 +1,5 @@
+---
+"nestjs-mixpanel": minor
+---
+
+Expose the underlying mixpanel-node instance via the `client` getter, so APIs this module does not wrap (batch tracking, groups, `people.increment`, imports, ...) are accessible without dropping the module. Calls made directly on the client bypass automatic user identification and IP resolution.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Production dependencies (mixpanel) get individual PRs so SDK updates
+  # are visible and land promptly; dev dependencies are grouped weekly.
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.8.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # NestJS Mixpanel
 
+[![npm version](https://img.shields.io/npm/v/nestjs-mixpanel.svg)](https://www.npmjs.com/package/nestjs-mixpanel)
+[![CI](https://github.com/ESnark/nestjs-mixpanel/actions/workflows/ci.yml/badge.svg)](https://github.com/ESnark/nestjs-mixpanel/actions/workflows/ci.yml)
+
 A powerful NestJS module for seamless Mixpanel analytics integration with automatic user identification and request context management.
 
 ## Features
@@ -256,6 +259,19 @@ this.mixpanel.people.setOnce({
 }, {
   $ignore_time: true,
 });
+```
+
+#### `client: Mixpanel.Mixpanel`
+
+The underlying [mixpanel-node](https://github.com/mixpanel/mixpanel-node) instance, for APIs this module does not wrap (batch tracking, groups, `people.increment`, imports, ...). Calls made directly on the client bypass automatic user identification and IP resolution — pass `distinct_id` and modifiers yourself:
+
+```typescript
+this.mixpanel.client.track_batch([
+  { event: 'signup', properties: { distinct_id: 'user-123' } },
+  { event: 'first_login', properties: { distinct_id: 'user-123' } },
+]);
+
+this.mixpanel.client.people.increment('user-123', 'login_count');
 ```
 
 #### `extractUserId(): string | undefined`

--- a/src/__tests__/mixpanel.service.test.ts
+++ b/src/__tests__/mixpanel.service.test.ts
@@ -90,6 +90,13 @@ describe('MixpanelService', () => {
     expect(service).toBeDefined();
   });
 
+  describe('client', () => {
+    it('should expose the underlying mixpanel client', () => {
+      expect(service.client).toBeDefined();
+      expect(service.client.track).toBe(mockTrack);
+    });
+  });
+
   describe('track', () => {
     it('should track an event with no properties', () => {
       // Mock empty request for header extraction

--- a/src/mixpanel.service.ts
+++ b/src/mixpanel.service.ts
@@ -186,6 +186,16 @@ export class MixpanelService {
     }
   }
 
+  /**
+   * The underlying mixpanel-node instance, for APIs this module does not
+   * wrap (batch tracking, groups, `people.increment`, imports, ...).
+   * Calls made directly on the client bypass this module's automatic user
+   * identification and IP resolution.
+   */
+  get client(): Mixpanel.Mixpanel {
+    return this.mixpanel;
+  }
+
   get people(): { set: PeopleFunction; setOnce: PeopleFunction } {
     return {
       set: this.peopleSet.bind(this) as PeopleFunction,


### PR DESCRIPTION
## Summary

Maintenance-infrastructure batch: prevents the two failure modes found in the original package review (a release shipping with a broken test suite, and the SDK silently falling 18 months behind), plus the API escape hatch.

## Changes

### CI workflow (`.github/workflows/ci.yml`)

The repository previously had **no test CI at all** — `release.yml` only builds on pushes to `main`, which is how v1.5.0 shipped with 14 failing tests. Every PR and push to `main` now runs lint → typecheck → tests → build on a **Node 20 / 22 / 24 matrix**. This PR itself is the first run of the workflow.

### Dependabot (`.github/dependabot.yml`)

Weekly update PRs, validated automatically by the new CI:
- npm production dependencies (i.e. `mixpanel`) individually, so SDK updates are visible and land promptly — addressing the root cause of the `^0.18.1` lag
- npm dev dependencies grouped into one PR
- GitHub Actions versions

Note: dependency PRs carry no changeset, so merging them doesn't trigger a release — bumps ship with the next release. For a `mixpanel` major/minor worth releasing on its own, add a changeset when merging.

### `client` escape hatch

`MixpanelService` now exposes the underlying mixpanel-node instance:

```typescript
this.mixpanel.client.track_batch([...]);
this.mixpanel.client.people.increment('user-123', 'login_count');
```

APIs the module doesn't wrap (batch tracking, groups, `people.increment`, imports) no longer require dropping the module. Direct client calls bypass automatic user identification and IP resolution — documented in the README. Includes a minor changeset, so merging this opens a 2.1.0 release PR.

### README

npm version + CI badges, and an API reference entry for `client` (examples verified to compile against the bundled mixpanel types).

## Validation

- 70/70 tests pass (new `client` getter test included)
- `tsc --noEmit`, ESLint, tsup build all clean
- Consumer-side typecheck of the built declarations, including the README `client` examples
- Both workflow YAML files parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS)_