### PR TITLE
Add Simplified ID Merge support (anonymous → identified user stitching)

### DIFF
--- a/.changeset/simplified-id-merge.md
+++ b/.changeset/simplified-id-merge.md
@@ -1,0 +1,5 @@
+---
+"nestjs-mixpanel": minor
+---
+
+Add Simplified ID Merge support via the `idMerge` option. The middleware maintains a device ID cookie (minting a UUID and setting the cookie when absent — no `cookie-parser` required), attaches `$device_id` to every event, and adds `$user_id` when the identification strategy resolves a user, so Mixpanel merges anonymous pre-login events and identified post-login events into a single user. Device-only events use the `$device:<uuid>` distinct_id Mixpanel derives; cookie attributes (name, Max-Age, SameSite, Secure, HttpOnly, Domain, Path) are configurable, and `SameSite=None` automatically adds `Secure`. When `idMerge` is enabled the `fallback` option is ignored, and profile updates are still never written to a device identity. Exports the new `IdMergeCookieOptions` type.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,44 @@ MixpanelModule.forRoot({
 })
 ```
 
+### Merging Anonymous and Identified Users (Simplified ID Merge)
+
+With an identification strategy alone, events sent before login stay anonymous forever. Enabling `idMerge` connects them: the module maintains a **device ID cookie** (minting a UUID and setting the cookie on the first request), attaches `$device_id` to every event, and adds `$user_id` whenever the identification strategy resolves a user. Mixpanel's [Simplified ID Merge](https://docs.mixpanel.com/docs/tracking-methods/id-management) then merges the pre-login anonymous events and post-login identified events into a single user — funnels and retention work across the login boundary.
+
+```typescript
+MixpanelModule.forRoot({
+  token: 'YOUR_MIXPANEL_TOKEN',
+  user: 'id',
+  idMerge: true,
+})
+```
+
+Cookie attributes can be customized:
+
+```typescript
+MixpanelModule.forRoot({
+  token: 'YOUR_MIXPANEL_TOKEN',
+  user: 'id',
+  idMerge: {
+    name: 'mp_device_id',    // default
+    maxAge: 31536000,        // seconds; default 1 year
+    path: '/',               // default
+    sameSite: 'Lax',         // default; 'None' automatically adds Secure
+    secure: true,            // default false — enable in production over HTTPS
+    httpOnly: true,          // default
+    // domain: '.example.com',
+  },
+})
+```
+
+Notes:
+
+- Your Mixpanel project must use the **Simplified ID Merge API** (the default for new projects — check Project Settings → Identity Merge).
+- Reading cookies does **not** require `cookie-parser`; the middleware parses the `Cookie` header itself (and prefers `cookie-parser` output when present).
+- When `idMerge` is enabled the `fallback` option is ignored — the device identity is the anonymous identity. Events without a device ID (e.g. background jobs outside a request) are sent anonymously.
+- Profile updates (`people.set` / `people.setOnce` without an explicit distinct ID) still require a resolved user ID; they are never written to a device identity.
+- The module sets a cookie on your users' browsers. Depending on your jurisdiction (e.g. GDPR/ePrivacy), analytics cookies may require user consent — gating tracking on consent is your application's responsibility.
+
 ### Additional Configuration
 
 #### IP Address Tracking

--- a/src/__tests__/async-storage.middleware.test.ts
+++ b/src/__tests__/async-storage.middleware.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { AsyncStorageMiddleware } from '../async-storage.middleware.js';
+import { AsyncStorageService, AsyncStorageContext } from '../async-storage.service.js';
+import type { MixpanelModuleOptions } from '../interface.js';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+const createRes = () => {
+  const headers: Record<string, unknown> = {};
+  return {
+    headers,
+    getHeader: (name: string) => headers[name],
+    setHeader: (name: string, value: unknown) => {
+      headers[name] = value;
+    },
+  };
+};
+
+const runMiddleware = (options: MixpanelModuleOptions | undefined, req: unknown, res: unknown) => {
+  const middleware = new AsyncStorageMiddleware(options);
+  let store: AsyncStorageContext | undefined;
+  middleware.use(req as any, res as any, () => {
+    store = AsyncStorageService.getAsyncLocalStorage().getStore();
+  });
+  return store!;
+};
+
+describe('AsyncStorageMiddleware', () => {
+  it('should store the request with a per-request ID and no device ID by default', () => {
+    const res = createRes();
+    const store = runMiddleware({ token: 't' }, { headers: {} }, res);
+
+    expect(store.id).toMatch(UUID_PATTERN);
+    expect(store.deviceId).toBeUndefined();
+    expect(res.headers['Set-Cookie']).toBeUndefined();
+  });
+
+  it('should work without options (bare module import)', () => {
+    const res = createRes();
+    const store = runMiddleware(undefined, { headers: {} }, res);
+
+    expect(store.id).toMatch(UUID_PATTERN);
+    expect(store.deviceId).toBeUndefined();
+  });
+
+  describe('ID merge', () => {
+    it('should mint a device ID and set the cookie when none is present', () => {
+      const res = createRes();
+      const store = runMiddleware({ token: 't', idMerge: true }, { headers: {} }, res);
+
+      expect(store.deviceId).toMatch(UUID_PATTERN);
+      expect(res.headers['Set-Cookie']).toBe(
+        `mp_device_id=${store.deviceId}; Path=/; Max-Age=31536000; SameSite=Lax; HttpOnly`,
+      );
+    });
+
+    it('should reuse an existing device ID cookie without setting a new one', () => {
+      const res = createRes();
+      const store = runMiddleware(
+        { token: 't', idMerge: true },
+        { headers: { cookie: 'foo=bar; mp_device_id=abc-123; baz=1' } },
+        res,
+      );
+
+      expect(store.deviceId).toBe('abc-123');
+      expect(res.headers['Set-Cookie']).toBeUndefined();
+    });
+
+    it('should prefer cookie-parser output when available', () => {
+      const res = createRes();
+      const store = runMiddleware(
+        { token: 't', idMerge: true },
+        { headers: {}, cookies: { mp_device_id: 'parsed-1' } },
+        res,
+      );
+
+      expect(store.deviceId).toBe('parsed-1');
+      expect(res.headers['Set-Cookie']).toBeUndefined();
+    });
+
+    it('should apply custom cookie options and force Secure for SameSite=None', () => {
+      const res = createRes();
+      const store = runMiddleware(
+        {
+          token: 't',
+          idMerge: {
+            name: 'did',
+            maxAge: 60,
+            sameSite: 'None',
+            domain: 'example.com',
+            httpOnly: false,
+          },
+        },
+        { headers: {} },
+        res,
+      );
+
+      expect(res.headers['Set-Cookie']).toBe(
+        `did=${store.deviceId}; Path=/; Max-Age=60; SameSite=None; Domain=example.com; Secure`,
+      );
+    });
+
+    it('should append to an existing Set-Cookie header', () => {
+      const res = createRes();
+      res.headers['Set-Cookie'] = 'session=xyz';
+
+      const store = runMiddleware({ token: 't', idMerge: true }, { headers: {} }, res);
+
+      expect(res.headers['Set-Cookie']).toEqual([
+        'session=xyz',
+        `mp_device_id=${store.deviceId}; Path=/; Max-Age=31536000; SameSite=Lax; HttpOnly`,
+      ]);
+    });
+  });
+});

--- a/src/__tests__/e2e/mixpanel.e2e.test.ts
+++ b/src/__tests__/e2e/mixpanel.e2e.test.ts
@@ -280,6 +280,50 @@ describe('MixpanelModule E2E Tests', () => {
     });
   });
 
+  describe('ID merge', () => {
+    beforeEach(async () => {
+      const TestModule = createTestModule({ header: 'x-user-id', idMerge: true });
+
+      const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [TestModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication();
+      await app.init();
+    });
+
+    it('should mint a device cookie and merge anonymous and identified events', async () => {
+      // Anonymous request mints the device cookie
+      const first = await request(app.getHttpServer()).post('/track').expect(201);
+
+      const setCookie = first.headers['set-cookie']?.[0];
+      expect(setCookie).toContain('mp_device_id=');
+      const deviceId = setCookie.match(/mp_device_id=([^;]+)/)?.[1];
+      expect(deviceId).toBeDefined();
+
+      expect(mockTrack).toHaveBeenLastCalledWith('test-event', {
+        action: 'e2e-test',
+        distinct_id: `$device:${deviceId}`,
+        $device_id: deviceId,
+      });
+
+      // Identified request presenting the same cookie carries both identities
+      const second = await request(app.getHttpServer())
+        .post('/track')
+        .set('Cookie', `mp_device_id=${deviceId}`)
+        .set('x-user-id', 'user-77')
+        .expect(201);
+
+      expect(second.headers['set-cookie']).toBeUndefined();
+      expect(mockTrack).toHaveBeenLastCalledWith('test-event', {
+        action: 'e2e-test',
+        distinct_id: 'user-77',
+        $device_id: deviceId,
+        $user_id: 'user-77',
+      });
+    });
+  });
+
   describe('AsyncStorage Context', () => {
     it('should properly clean up AsyncStorage context', async () => {
       const TestModule = createTestModule({ fallback: 'request-context' });

--- a/src/__tests__/mixpanel.service.test.ts
+++ b/src/__tests__/mixpanel.service.test.ts
@@ -33,6 +33,7 @@ describe('MixpanelService', () => {
     asyncStorageService = {
       get: vi.fn(),
       getId: vi.fn().mockReturnValue('default-cls-id'),
+      getDeviceId: vi.fn(),
       getRequest: vi.fn(),
       getUser: vi.fn(),
       getSession: vi.fn(),
@@ -63,6 +64,7 @@ describe('MixpanelService', () => {
     const asyncStorage = {
       get: vi.fn(),
       getId: vi.fn().mockReturnValue('cls-context-123'),
+      getDeviceId: vi.fn(),
       getRequest: vi.fn(),
       getUser: vi.fn(),
       getSession: vi.fn(),
@@ -299,6 +301,76 @@ describe('MixpanelService', () => {
       });
 
       expect(fallbackService.extractUserId()).toBeUndefined();
+    });
+  });
+
+  describe('ID merge', () => {
+    it('should track device-only events with $device_id and a derived distinct_id', async () => {
+      const { service: idService, asyncStorage } = await createServiceWithOptions({
+        token: 'test-token',
+        header: 'x-user-id',
+        idMerge: true,
+      });
+      asyncStorage.getRequest.mockReturnValue({ headers: {} });
+      asyncStorage.getDeviceId.mockReturnValue('device-abc');
+
+      idService.track('page_viewed');
+
+      expect(mockTrack).toHaveBeenCalledWith('page_viewed', {
+        distinct_id: '$device:device-abc',
+        $device_id: 'device-abc',
+      });
+    });
+
+    it('should attach both $device_id and $user_id when the user is identified', async () => {
+      const { service: idService, asyncStorage } = await createServiceWithOptions({
+        token: 'test-token',
+        header: 'x-user-id',
+        idMerge: true,
+      });
+      asyncStorage.getRequest.mockReturnValue({ headers: { 'x-user-id': 'user-9' } });
+      asyncStorage.getDeviceId.mockReturnValue('device-abc');
+
+      idService.track('purchase', { amount: 10 });
+
+      expect(mockTrack).toHaveBeenCalledWith('purchase', {
+        distinct_id: 'user-9',
+        $device_id: 'device-abc',
+        $user_id: 'user-9',
+        amount: 10,
+      });
+    });
+
+    it('should stay anonymous when no device ID is available (non-HTTP context)', async () => {
+      const { service: idService, asyncStorage } = await createServiceWithOptions({
+        token: 'test-token',
+        idMerge: true,
+      });
+      asyncStorage.getDeviceId.mockReturnValue(undefined);
+
+      idService.track('background-job');
+
+      expect(mockTrack).toHaveBeenCalledWith('background-job', {
+        distinct_id: '',
+      });
+    });
+
+    it('should ignore the fallback option when ID merge is enabled', async () => {
+      const { service: idService, asyncStorage } = await createServiceWithOptions({
+        token: 'test-token',
+        idMerge: true,
+        fallback: 'request-context',
+      });
+      asyncStorage.getDeviceId.mockReturnValue('device-abc');
+
+      expect(idService.extractUserId()).toBeUndefined();
+      expect(asyncStorage.getId).not.toHaveBeenCalled();
+
+      idService.track('page_viewed');
+      expect(mockTrack).toHaveBeenCalledWith('page_viewed', {
+        distinct_id: '$device:device-abc',
+        $device_id: 'device-abc',
+      });
     });
   });
 

--- a/src/async-storage.middleware.ts
+++ b/src/async-storage.middleware.ts
@@ -1,21 +1,103 @@
-import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Inject, Injectable, NestMiddleware, Optional } from '@nestjs/common';
 import type { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'node:crypto';
-import { AsyncStorageService } from './async-storage.service.js';
-import { REQUEST_CTX_KEY } from './constant.js';
+import { AsyncStorageService, AsyncStorageContext } from './async-storage.service.js';
+import { MIXPANEL_OPTIONS, REQUEST_CTX_KEY } from './constant.js';
+import type { IdMergeCookieOptions, MixpanelModuleOptions } from './interface.js';
+
+type ResolvedCookieOptions = Required<Omit<IdMergeCookieOptions, 'domain'>> & {
+  domain?: string;
+};
+
+const DEFAULT_DEVICE_COOKIE: ResolvedCookieOptions = {
+  name: 'mp_device_id',
+  maxAge: 60 * 60 * 24 * 365,
+  path: '/',
+  sameSite: 'Lax',
+  secure: false,
+  httpOnly: true,
+};
 
 @Injectable()
 export class AsyncStorageMiddleware implements NestMiddleware {
+  constructor(
+    @Optional() @Inject(MIXPANEL_OPTIONS) private readonly options?: MixpanelModuleOptions,
+  ) {}
+
   use(req: Request, res: Response, next: NextFunction) {
     const asyncLocalStorage = AsyncStorageService.getAsyncLocalStorage();
 
-    const context = {
+    const context: AsyncStorageContext = {
       id: randomUUID(),
       [REQUEST_CTX_KEY]: req,
     };
 
+    if (this.options?.idMerge) {
+      context.deviceId = this.resolveDeviceId(req, res);
+    }
+
     asyncLocalStorage.run(context, () => {
       next();
     });
+  }
+
+  private resolveDeviceId(req: Request, res: Response): string {
+    const config: ResolvedCookieOptions = {
+      ...DEFAULT_DEVICE_COOKIE,
+      ...(typeof this.options?.idMerge === 'object' ? this.options.idMerge : {}),
+    };
+
+    const existing = this.readCookie(req, config.name);
+    if (existing) {
+      return existing;
+    }
+
+    const deviceId = randomUUID();
+    this.appendSetCookie(res, deviceId, config);
+    return deviceId;
+  }
+
+  private readCookie(req: Request, name: string): string | undefined {
+    // Prefer cookie-parser output when the application uses it
+    const parsed = (req as { cookies?: Record<string, string> }).cookies?.[name];
+    if (parsed) {
+      return parsed;
+    }
+
+    const header = req.headers?.cookie;
+    if (!header) {
+      return undefined;
+    }
+    for (const part of header.split(';')) {
+      const separator = part.indexOf('=');
+      if (separator === -1) continue;
+      if (part.slice(0, separator).trim() === name) {
+        return decodeURIComponent(part.slice(separator + 1).trim());
+      }
+    }
+    return undefined;
+  }
+
+  private appendSetCookie(res: Response, value: string, config: ResolvedCookieOptions): void {
+    const parts = [
+      `${config.name}=${value}`,
+      `Path=${config.path}`,
+      `Max-Age=${config.maxAge}`,
+      `SameSite=${config.sameSite}`,
+    ];
+    if (config.domain) parts.push(`Domain=${config.domain}`);
+    if (config.httpOnly) parts.push('HttpOnly');
+    // Browsers require Secure for SameSite=None
+    if (config.secure || config.sameSite === 'None') parts.push('Secure');
+
+    const cookie = parts.join('; ');
+    const previous = res.getHeader('Set-Cookie');
+    if (previous === undefined) {
+      res.setHeader('Set-Cookie', cookie);
+    } else if (Array.isArray(previous)) {
+      res.setHeader('Set-Cookie', [...previous.map(String), cookie]);
+    } else {
+      res.setHeader('Set-Cookie', [String(previous), cookie]);
+    }
   }
 }

--- a/src/async-storage.service.ts
+++ b/src/async-storage.service.ts
@@ -5,6 +5,7 @@ import { REQUEST_CTX_KEY } from './constant.js';
 
 export interface AsyncStorageContext {
   id: string;
+  deviceId?: string;
   request?: any;
   [key: string]: any;
 }
@@ -36,6 +37,11 @@ export class AsyncStorageService {
   getId(): string | undefined {
     const store = AsyncStorageService.storage.getStore();
     return store?.id;
+  }
+
+  getDeviceId(): string | undefined {
+    const store = AsyncStorageService.storage.getStore();
+    return store?.deviceId;
   }
 
   getRequest(): any {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export type {
   MixpanelModuleOptions,
   MixpanelModuleAsyncOptions,
   FallbackIdStrategy,
+  IdMergeCookieOptions,
 } from './interface.js';

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -22,11 +22,45 @@ export type FallbackIdStrategy =
   | 'request-context'
   | ((request: unknown) => string | undefined);
 
+/**
+ * Device ID cookie attributes for Simplified ID Merge.
+ */
+export type IdMergeCookieOptions = {
+  /** Cookie name. Default: `'mp_device_id'` */
+  name?: string;
+  /** Max-Age in seconds. Default: `31536000` (1 year) */
+  maxAge?: number;
+  /** Default: `'/'` */
+  path?: string;
+  domain?: string;
+  /**
+   * Default: `'Lax'`. `'None'` automatically adds the `Secure` attribute,
+   * as required by browsers.
+   */
+  sameSite?: 'Strict' | 'Lax' | 'None';
+  /** Default: `false`. Enable in production when serving over HTTPS. */
+  secure?: boolean;
+  /** Default: `true` — the cookie only exists for server-side analytics. */
+  httpOnly?: boolean;
+};
+
 type CommonModuleOptions = {
   token: MixpanelProjectToken;
   initConfig?: InitConfig;
   ipHeader?: IpHeaderOption;
   fallback?: FallbackIdStrategy;
+  /**
+   * Enables Mixpanel Simplified ID Merge support. The middleware maintains a
+   * device ID cookie (minting a UUID and setting the cookie when absent), and
+   * every event carries `$device_id` — plus `$user_id` when the identification
+   * strategy resolves one — so anonymous pre-login events and identified
+   * post-login events are merged into a single user by Mixpanel.
+   *
+   * Requires the Mixpanel project to use the Simplified ID Merge API. When
+   * enabled, the `fallback` option is ignored: the device identity IS the
+   * anonymous identity.
+   */
+  idMerge?: boolean | IdMergeCookieOptions;
 };
 
 export type MixpanelModuleOptions =

--- a/src/mixpanel.service.ts
+++ b/src/mixpanel.service.ts
@@ -41,12 +41,16 @@ export class MixpanelService {
 
   track: TrackFunction = (event, properties, callback) => {
     const userId = this.extractUserId();
+    const deviceId = this.options.idMerge ? this.asyncStorage.getDeviceId() : undefined;
     const ip = this.getIp();
     const finalProperties = {
       // An empty distinct_id is Mixpanel's documented way to send an event
       // that is not associated with any user, so unresolved identities do
-      // not pollute unique-user counts.
-      distinct_id: userId ?? '',
+      // not pollute unique-user counts. With ID merge, `$device:<uuid>` is
+      // the distinct_id Mixpanel derives for device-only events.
+      distinct_id: userId ?? (deviceId ? `$device:${deviceId}` : ''),
+      ...(deviceId && { $device_id: deviceId }),
+      ...(deviceId && userId && { $user_id: userId }),
       ...(ip && { ip }),
       ...properties,
     };
@@ -234,33 +238,23 @@ export class MixpanelService {
 
   extractUserId(): string | undefined {
     try {
-      let userId: string | undefined;
-      let strategyConfigured = true;
-
-      if ('header' in this.options) {
-        const request = this.asyncStorage.getRequest();
-        userId = request?.headers?.[this.options.header.toLowerCase()];
-      } else if ('session' in this.options) {
-        const session = this.asyncStorage.getSession();
-        userId = this.extractValue(this.options.session, session);
-      } else if ('user' in this.options) {
-        const user = this.asyncStorage.getUser();
-        userId = this.extractValue(this.options.user, user);
-      } else if ('cookie' in this.options) {
-        userId = this.asyncStorage.getCookie(this.options.cookie);
-      } else {
-        strategyConfigured = false;
-      }
+      const userId = this.extractStrategyUserId();
 
       if (userId) {
         return userId;
       }
 
-      if (strategyConfigured && !this.warnedExtractionFailure) {
+      if (this.hasStrategy() && !this.warnedExtractionFailure) {
         this.warnedExtractionFailure = true;
         this.logger.warn(
           'Could not extract a user ID with the configured identification strategy; the fallback identity will be used. This is logged only once.',
         );
+      }
+
+      // With ID merge, the device identity is the anonymous identity, so the
+      // fallback option does not apply.
+      if (this.options.idMerge) {
+        return undefined;
       }
 
       return this.resolveFallbackId();
@@ -268,6 +262,34 @@ export class MixpanelService {
       this.logger.warn(`Failed to extract user ID from request: ${error}`);
     }
 
+    return undefined;
+  }
+
+  private hasStrategy(): boolean {
+    return (
+      'header' in this.options ||
+      'session' in this.options ||
+      'user' in this.options ||
+      'cookie' in this.options
+    );
+  }
+
+  private extractStrategyUserId(): string | undefined {
+    if ('header' in this.options) {
+      const request = this.asyncStorage.getRequest();
+      return request?.headers?.[this.options.header.toLowerCase()];
+    }
+    if ('session' in this.options) {
+      const session = this.asyncStorage.getSession();
+      return this.extractValue(this.options.session, session);
+    }
+    if ('user' in this.options) {
+      const user = this.asyncStorage.getUser();
+      return this.extractValue(this.options.user, user);
+    }
+    if ('cookie' in this.options) {
+      return this.asyncStorage.getCookie(this.options.cookie);
+    }
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

With an identification strategy alone, events sent before login stay anonymous forever. The new `idMerge` option connects them using Mixpanel's Simplified ID Merge: pre-login anonymous events and post-login identified events merge into a single user, so funnels and retention work across the login boundary.

```typescript
MixpanelModule.forRoot({
  token: '...',
  user: 'id',
  idMerge: true, // or { name, maxAge, path, domain, sameSite, secure, httpOnly }
})
```

## How it works

1. **Middleware** maintains a device ID cookie (default `mp_device_id`): mints a UUID and sets the cookie when absent, reuses it when presented. Reading does **not** require `cookie-parser` — the `Cookie` header is parsed directly (with `cookie-parser` output preferred when present).
2. **Every event carries `$device_id`**, plus `$user_id` when the identification strategy resolves a user. Device-only events use the `$device:<uuid>` distinct_id Mixpanel derives; identified events use the user ID.
3. Mixpanel's Simplified ID Merge links the two identities server-side.

## Semantics

- When `idMerge` is enabled, the `fallback` option is ignored — the device identity is the anonymous identity. Contexts without a device ID (background jobs) stay anonymous (`distinct_id: ''`).
- Profile updates (`people.set`/`setOnce` without an explicit distinct ID) still require a resolved user ID — never written to a device identity.
- `SameSite=None` automatically adds `Secure`, as browsers require. Defaults: `HttpOnly`, `SameSite=Lax`, `Max-Age` 1 year, `Path=/`.
- README documents the Simplified ID Merge project requirement and the cookie-consent (GDPR/ePrivacy) responsibility.

## Changes

- `AsyncStorageMiddleware`: optional `MIXPANEL_OPTIONS` injection, device cookie read/mint/Set-Cookie (manual header manipulation, appends to existing `Set-Cookie`), device ID stored in the request context.
- `MixpanelService`: identity resolution split into strategy extraction vs fallback; `track` attaches `$device_id`/`$user_id` and derives `distinct_id` accordingly.
- New exported `IdMergeCookieOptions` type; minor changeset (joins the pending 2.1.0 release PR [#10](https://github.com/ESnark/nestjs-mixpanel/pull/10) if it hasn't been merged yet).

## Validation

- 82/82 tests: new middleware unit suite (mint/reuse/cookie-parser/custom attributes/Set-Cookie append/bare-module), service identity tests (device-only, identified, non-HTTP, fallback-ignored), and an e2e flow that mints the cookie on an anonymous request and verifies the identified follow-up request carries both `$device_id` and `$user_id`.
- `tsc`, ESLint, tsup build clean; consumer-side typecheck of the published declarations including the new option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS)_