### PR TITLE
Fix flaky memory test in CI and exclude TypeScript 7 from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: 'development'
+    ignore:
+      # typescript-eslint does not support TypeScript 7 yet:
+      # https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
 
       - name: Test
         run: pnpm test
+        env:
+          # The memory-leak e2e test forces GC between measurements; without
+          # --expose-gc its per-request threshold is at the mercy of GC timing
+          # and fails intermittently (observed on Node 24 runners).
+          NODE_OPTIONS: --expose-gc
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
## Summary

Fixes the two CI failure causes diagnosed on the Dependabot PRs ([#13](https://github.com/ESnark/nestjs-mixpanel/pull/13), [#14](https://github.com/ESnark/nestjs-mixpanel/pull/14), [#15](https://github.com/ESnark/nestjs-mixpanel/pull/15)). No package changes — CI/config only, no changeset.

## 1. Memory test flake → run CI tests with `--expose-gc`

#13 and #14 failed only on the Node 24 job, both at `mixpanel-memory.e2e.test.ts:137` (`expected 74.3/74.7 to be less than 50`) — unrelated to the action bumps themselves. The memory-leak test is written to force GC between measurements (`if (global.gc)` guards throughout, matching the dedicated `test:memory` script), but CI runs plain `pnpm test` without `--expose-gc`, so the 50KB/request assertion rides on GC timing: per-batch measurements swing from **-26KB to +136KB per request**.

Setting `NODE_OPTIONS: --expose-gc` on the Test step makes the test run as designed. Verified locally:

| | per-request increase |
|---|---|
| without `--expose-gc` (CI logs) | -26.6KB ~ +136.8KB, avg 74.7KB ❌ |
| with `--expose-gc` | 0.43 ~ 2.12KB, avg **0.62KB** ✅ |

## 2. TypeScript 7 → Dependabot ignore rule

#15 (grouped dev-dependency updates) fails `pnpm lint` on all three Node versions with `Error: typescript-eslint does not support TS 7.0` — the group includes `typescript` 5.8.3 → 7.0.2, which [typescript-eslint doesn't support yet](https://github.com/typescript-eslint/typescript-eslint/issues/10940). Major TypeScript updates are now ignored (with a comment pointing at the tracking issue so the rule can be removed later).

## After merging

- Re-run CI on #13 and #14 (or comment `·@·d·ependabot r·ebase`) — they should go green.
- Comment `·@·d·ependabot r·ecreate` on #15 so the group is rebuilt without the TypeScript major; its CI will then judge the remaining majors (eslint 10, vitest 4, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS)_