### PR TITLE
Fix release workflow for changesets/action v2 (unblocks 2.1.0 publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,27 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # Detect pending changesets before the action runs, so the publish gate
+      # below does not depend on the action's output names (hasChangesets was
+      # renamed to has-changesets in v2; a stale name silently skips publish).
+      - name: Check for pending changesets
+        id: pending
+        shell: bash
+        run: |
+          if find .changeset -name '*.md' ! -name 'README.md' | grep -q .; then
+            echo "changesets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changesets=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@v2
         with:
-          version: pnpm changeset version
-          commit: "chore: release"
-          title: "chore: release"
+          # changesets/action v2 renamed version/commit/title to these names
+          version-script: pnpm changeset version
+          commit-message: "chore: release"
+          pr-title: "chore: release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -64,7 +78,7 @@ jobs:
       # merged) this publishes any version not yet on the registry.
       - name: Publish to npm
         id: publish
-        if: steps.changesets.outputs.hasChangesets == 'false'
+        if: steps.pending.outputs.changesets == 'false'
         shell: bash
         run: |
           pnpm changeset publish | tee publish-output.log


### PR DESCRIPTION
## Summary

**Every Release workflow run on `main` has failed since [#11](https://github.com/ESnark/nestjs-mixpanel/pull/11) (changesets/action v1 → v2) merged** — including the run for the release PR [#10](https://github.com/ESnark/nestjs-mixpanel/pull/10), so **v2.1.0 is version-bumped on `main` but was never published to npm**.

## Root cause

changesets/action v2 renamed its inputs and errors out immediately on the old names:

```
Error: The following inputs have been renamed:
- "version" -> "version-script"
- "commit" -> "commit-message"
- "title" -> "pr-title"
```

v2 also renamed the `hasChangesets` output to `has-changesets` ([README](https://github.com/changesets/action)), which would have made our publish gate (`steps.changesets.outputs.hasChangesets == 'false'`) evaluate against an empty string and **silently skip publishing forever** even after fixing the inputs.

## Changes

1. Rename the action inputs to the v2 names (`version-script`, `commit-message`, `pr-title`).
2. Replace the publish gate with a self-computed pending-changesets check (from `.changeset/*.md`, evaluated before the action runs), so it no longer depends on the action's output naming across future majors.

Validated: workflow YAML parses; the pending check evaluates `false` on the current `main` state (changesets consumed by #10), which is exactly the state where publishing must run.

## After merging

The push to `main` triggers the fixed Release workflow: no pending changesets → the publish step runs → `changeset publish` detects 2.1.0 is not on the registry and publishes it via OIDC, pushes `v2.1.0`, and creates the GitHub release. **Merging this PR completes the stuck 2.1.0 release** (`client` getter + Simplified ID Merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS)_