### PR TITLE
Run release on Node 24 and detect publishes via the registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          # @changesets/cli v3 requires Node >= 22.8 (it calls
+          # module.enableCompileCache unconditionally).
+          node-version: 24
           cache: 'pnpm'
 
-      # Trusted publishing requires npm >= 11.5.1; Node 20 bundles npm 10.
+      # Trusted publishing requires npm >= 11.5.1.
       - name: Update npm for trusted publishing
         run: npm install -g npm@11
 
@@ -76,15 +78,21 @@ jobs:
       # When changesets are pending this push only updated the release PR, so
       # publishing is skipped; when none are pending (the release PR was just
       # merged) this publishes any version not yet on the registry.
+      # Whether a publish is needed is decided by asking the registry, not by
+      # parsing changeset output (its log format changed in @changesets/cli v3).
       - name: Publish to npm
         id: publish
         if: steps.pending.outputs.changesets == 'false'
         shell: bash
         run: |
-          pnpm changeset publish | tee publish-output.log
-          if grep -q "New tag:" publish-output.log; then
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "nestjs-mixpanel@${VERSION}" version >/dev/null 2>&1; then
+            echo "nestjs-mixpanel@${VERSION} is already on the registry; nothing to publish."
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          else
+            pnpm changeset publish
             echo "published=true" >> "$GITHUB_OUTPUT"
-            echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Push Git Tag and Create GitHub Release


### PR DESCRIPTION
## Summary

[#19](https://github.com/ESnark/nestjs-mixpanel/pull/19)'s input fix worked (the changesets/action v2 step now runs clean and the publish gate fires correctly), but [run #22](https://github.com/ESnark/nestjs-mixpanel/actions/runs/33050136139) exposed **two more incompatibilities from the `@changesets/cli` v2 → v3 major** (merged in #18) that still block the 2.1.0 publish.

## 1. `@changesets/cli` v3 requires Node ≥ 22.8

```
TypeError: enableCompileCache is not a function
    at @changesets/cli/bin.js:6
Node.js v20.20.2
```

v3's bin calls `module.enableCompileCache()` unconditionally (added in Node 22.8), while the release job pinned Node 20. CI never caught this because the Node 20 CI job doesn't invoke the changeset CLI. → The release job now runs on **Node 24**. (`npm install -g npm@11` stays, guaranteeing npm ≥ 11.5.1 for trusted publishing.)

## 2. v3 removed the `"New tag:"` output the publish step grepped

The tag-push/GitHub-release steps were gated on `grep "New tag:"` in the publish output; v3 replaced that logging with spinner-style output ("Creating git tags..."), so even after the Node fix the tag and release would silently never be created. The gate now **asks the registry instead of parsing logs**: if `package.json`'s version is already published, skip; otherwise run `changeset publish` and set the outputs. Verified against the live registry: `2.0.0 → skip`, `2.1.0 → publish` — exactly the pending state.

## After merging

The push to `main` runs the fixed workflow: no pending changesets → registry check finds 2.1.0 unpublished → `changeset publish` publishes it via OIDC → tag `v2.1.0` is pushed and the GitHub release is created. **Merging this completes the stuck 2.1.0 release.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSC8NXBWrDqk25SbhsGCoS)_